### PR TITLE
Add domain builder tools

### DIFF
--- a/testCases/casual/001.single.service.scale.payload.conf
+++ b/testCases/casual/001.single.service.scale.payload.conf
@@ -1,8 +1,8 @@
 locustfile = 001.single.service.scale.payload.py
 headless = true
 csv-full-history = true
-host = http://host2:8201
+host = http://localhost:8201
 users = 1
 spawn-rate = 1
 run-time = 60s
-use-remote-nodes = true
+use-remote-nodes = false

--- a/testCases/casual/001.single.service.scale.payload.py
+++ b/testCases/casual/001.single.service.scale.payload.py
@@ -5,6 +5,8 @@ import os
 from casual.performance.test import telegraf
 from casual.performance.test import casual
 from casual.performance.test import helpers
+from casual.performance.test import configuration
+
 import inspect
 
 import user_config
@@ -14,7 +16,7 @@ import user_config
 # Global declarations needed in locust testfiles
 
 starttime=float()
-configuration={}
+stored_configuration={}
 
 @events.init_command_line_parser.add_listener
 def _(parser):
@@ -72,57 +74,15 @@ def domainX( base: str, environment: dict):
    name = inspect.currentframe().f_code.co_name
    home = os.path.join( base, name)
 
-   # Note the double ${{}} to escape f-string functionality
+   config_domain_X = configuration.Configuration( name)
+
    return {
             "name" : name,
             "home" : home,
             "remote" : user_config.get( name),
             "files" : 
             [
-               {
-                  "filename" : "configuration/domain.yaml",
-                  "content" : f"""
-system:
-  resources:
-    - key: "rm-mockup"
-      server: "rm-proxy-casual-mockup"
-      xa_struct_name: "casual_mockup_xa_switch_static"
-      libraries:
-        - "casual-mockup-rm"
-      paths:
-        library:
-          - "${{CASUAL_HOME}}/lib"
-
-domain:
-  name: {name}
-
-  transaction:
-    resources:
-      - name: example-resource-server
-        key: rm-mockup
-        instances: 2
-
-  servers:
-    - alias: casual-example-server
-      path: ${{CASUAL_HOME}}/example/bin/casual-example-server
-      instances: 1
-
-  executables:
-    - alias: casual-http-inbound
-      path: ${{CASUAL_HOME}}/nginx/sbin/nginx
-      arguments: 
-        - "-c" 
-        - ${{CASUAL_DOMAIN_HOME}}/configuration/nginx.conf
-        - "-p"
-        - ${{CASUAL_DOMAIN_HOME}}
-
-    - alias: casual-event-service-log
-      path: ${{CASUAL_HOME}}/bin/casual-event-service-log
-      arguments: [ --file, logs/statistics.log ]
-      instances: 1
-
-"""
-               }
+                config_domain_X.configuration_file_entry()
             ],
             "nginx_port" : user_config.port( name)
          }
@@ -131,11 +91,11 @@ domain:
 @events.test_start.add_listener
 def on_test_start( environment, **kwargs):
    global starttime
-   global configuration
+   global stored_configuration
 
    base = casual.make_base()
 
-   configuration = {
+   stored_configuration = {
       "domains": 
       [
          telegraf.config( base, "telegrafA", user_config.get( "telegrafA")),
@@ -143,15 +103,15 @@ def on_test_start( environment, **kwargs):
       ]
    }
 
-   casual.on_test_start( configuration, environment)
-   starttime = helpers.write_start_information( configuration, environment)
+   casual.on_test_start( stored_configuration, environment)
+   starttime = helpers.write_start_information( stored_configuration, environment)
 
 @events.test_stop.add_listener
 def on_test_stop( environment, **kwargs):
    global starttime
-   global configuration
+   global stored_configuration
 
-   casual.on_test_stop( configuration, environment)
+   casual.on_test_stop( stored_configuration, environment)
 
-   helpers.write_stop_information( configuration, environment, starttime)
+   helpers.write_stop_information( stored_configuration, environment, starttime)
 

--- a/testCases/casual/002.scale.services.constant.payload.py
+++ b/testCases/casual/002.scale.services.constant.payload.py
@@ -5,6 +5,8 @@ import os
 from casual.performance.test import telegraf
 from casual.performance.test import casual
 from casual.performance.test import helpers
+from casual.performance.test import configuration
+
 import inspect
 
 import user_config
@@ -14,7 +16,7 @@ import user_config
 # Global declarations needed in locust testfiles
 
 starttime=float()
-configuration={}
+stored_configuration={}
 
 @events.init_command_line_parser.add_listener
 def _(parser):
@@ -40,74 +42,32 @@ def domainX( base: str, environment: dict):
    domain definition for a testdomain
    """
 
-   # Use name of function as name of domain
+  # Use name of function as name of domain
    name = inspect.currentframe().f_code.co_name
    home = os.path.join( base, name)
 
-   # Note the double ${{}} to escape f-string functionality
+   config_domain_X = configuration.Configuration( name)
+   config_domain_X.domain.servers.find_first("casual-example-server").instances = 10
+
    return {
             "name" : name,
             "home" : home,
             "remote" : user_config.get( name),
             "files" : 
             [
-               {
-                  "filename" : "configuration/domain.yaml",
-                  "content" : f"""
-system:
-  resources:
-    - key: "rm-mockup"
-      server: "rm-proxy-casual-mockup"
-      xa_struct_name: "casual_mockup_xa_switch_static"
-      libraries:
-        - "casual-mockup-rm"
-      paths:
-        library:
-          - "${{CASUAL_HOME}}/lib"
-
-domain:
-  name: {name}
-
-  transaction:
-    resources:
-      - name: example-resource-server
-        key: rm-mockup
-        instances: 2
-
-  servers:
-    - alias: casual-example-server
-      path: ${{CASUAL_HOME}}/example/bin/casual-example-server
-      instances: 10
-
-  executables:
-    - alias: casual-http-inbound
-      path: ${{CASUAL_HOME}}/nginx/sbin/nginx
-      arguments: 
-        - "-c" 
-        - ${{CASUAL_DOMAIN_HOME}}/configuration/nginx.conf
-        - "-p"
-        - ${{CASUAL_DOMAIN_HOME}}
-
-    - alias: casual-event-service-log
-      path: ${{CASUAL_HOME}}/bin/casual-event-service-log
-      arguments: [ --file, logs/statistics.log ]
-      instances: 1
-
-"""
-               }
+                config_domain_X.configuration_file_entry()
             ],
             "nginx_port" : user_config.port( name)
          }
 
-
 @events.test_start.add_listener
 def on_test_start( environment, **kwargs):
    global starttime
-   global configuration
+   global stored_configuration
 
    base = casual.make_base()
 
-   configuration = {
+   stored_configuration = {
       "domains": 
       [
          telegraf.config( base, "telegrafA", user_config.get( "telegrafA")),
@@ -115,15 +75,15 @@ def on_test_start( environment, **kwargs):
       ]
    }
 
-   casual.on_test_start( configuration, environment)
-   starttime = helpers.write_start_information( configuration, environment)
+   casual.on_test_start( stored_configuration, environment)
+   starttime = helpers.write_start_information( stored_configuration, environment)
 
 @events.test_stop.add_listener
 def on_test_stop( environment, **kwargs):
    global starttime
-   global configuration
+   global stored_configuration
 
-   casual.on_test_stop( configuration, environment)
+   casual.on_test_stop( stored_configuration, environment)
 
-   helpers.write_stop_information( configuration, environment, starttime)
+   helpers.write_stop_information( stored_configuration, environment, starttime)
 

--- a/testCases/casual/004.scale.services.constant.payload.multiple.domains.py
+++ b/testCases/casual/004.scale.services.constant.payload.multiple.domains.py
@@ -6,6 +6,8 @@ import os
 from casual.performance.test import telegraf
 from casual.performance.test import casual
 from casual.performance.test import helpers
+from casual.performance.test import configuration
+
 import inspect
 
 import user_config
@@ -16,7 +18,7 @@ import time
 # Global declarations needed in locust testfiles
 
 starttime=float()
-configuration={}
+stored_configuration={}
 
 @events.init_command_line_parser.add_listener
 def _(parser):
@@ -47,59 +49,18 @@ def domainX( base: str, environment: dict):
    name = inspect.currentframe().f_code.co_name
    home = os.path.join( base, name)
 
-   # Note the double ${{}} to escape f-string functionality
+   config_domain_X = configuration.Configuration( name, example_server = False)
+   config_domain_X.domain.gateway.outbound.groups.append("outbound").connections.append( 
+      user_config.get("domainY")["gateway_inbound_address"]
+    )
+
    return {
             "name" : name,
             "home" : home,
             "remote" : user_config.get( name),
             "files" : 
             [
-               {
-                  "filename" : "configuration/domain.yaml",
-                  "content" : f"""
-system:
-  resources:
-    - key: "rm-mockup"
-      server: "rm-proxy-casual-mockup"
-      xa_struct_name: "casual_mockup_xa_switch_static"
-      libraries:
-        - "casual-mockup-rm"
-      paths:
-        library:
-          - "${{CASUAL_HOME}}/lib"
-
-domain:
-  name: {name}
-
-  transaction:
-    resources:
-      - name: example-resource-server
-        key: rm-mockup
-        instances: 2
-
-  executables:
-    - alias: casual-http-inbound
-      path: ${{CASUAL_HOME}}/nginx/sbin/nginx
-      arguments: 
-        - "-c" 
-        - ${{CASUAL_DOMAIN_HOME}}/configuration/nginx.conf
-        - "-p"
-        - ${{CASUAL_DOMAIN_HOME}}
-
-    - alias: casual-event-service-log
-      path: ${{CASUAL_HOME}}/bin/casual-event-service-log
-      arguments: [ --file, logs/statistics.log ]
-      instances: 1
-
-  gateway:
-    outbound:
-      groups:
-        - alias: outbound
-          connections:
-            - address: {user_config.get("domainY")["gateway_inbound_address"]}
-
-"""
-               }
+                config_domain_X.configuration_file_entry()
             ],
             "nginx_port" : user_config.port( name)
          }
@@ -113,64 +74,20 @@ def domainY( base: str, environment: dict):
    name = inspect.currentframe().f_code.co_name
    home = os.path.join( base, name)
 
-   # Note the double ${{}} to escape f-string functionality
+   config_domain_Y = configuration.Configuration( name)
+   config_domain_Y.domain.gateway.inbound.groups.append("inbound").connections.append( 
+      user_config.get("domainY")["gateway_inbound_address"]
+    )
+   
+   config_domain_Y.domain.servers.find_first("casual-example-server").instances = 10
+
    return {
             "name" : name,
             "home" : home,
             "remote" : user_config.get( name),
             "files" : 
             [
-               {
-                  "filename" : "configuration/domain.yaml",
-                  "content" : f"""
-system:
-  resources:
-    - key: "rm-mockup"
-      server: "rm-proxy-casual-mockup"
-      xa_struct_name: "casual_mockup_xa_switch_static"
-      libraries:
-        - "casual-mockup-rm"
-      paths:
-        library:
-          - "${{CASUAL_HOME}}/lib"
-
-domain:
-  name: {name}
-
-  transaction:
-    resources:
-      - name: example-resource-server
-        key: rm-mockup
-        instances: 2
-
-  servers:
-    - alias: casual-example-server
-      path: ${{CASUAL_HOME}}/example/bin/casual-example-server
-      instances: 10
-
-  executables:
-    - alias: casual-http-inbound
-      path: ${{CASUAL_HOME}}/nginx/sbin/nginx
-      arguments: 
-        - "-c" 
-        - ${{CASUAL_DOMAIN_HOME}}/configuration/nginx.conf
-        - "-p"
-        - ${{CASUAL_DOMAIN_HOME}}
-
-    - alias: casual-event-service-log
-      path: ${{CASUAL_HOME}}/bin/casual-event-service-log
-      arguments: [ --file, logs/statistics.log ]
-      instances: 1
-
-  gateway:
-    inbound:
-      groups:
-        - alias: inbound
-          connections:
-            - address: {user_config.get("domainY")["gateway_inbound_address"]}
-
-"""
-               }
+                config_domain_Y.configuration_file_entry()
             ],
             "nginx_port" : user_config.port( name)
          }
@@ -178,11 +95,11 @@ domain:
 @events.test_start.add_listener
 def on_test_start( environment, **kwargs):
    global starttime
-   global configuration
+   global stored_configuration
 
    base = casual.make_base()
 
-   configuration = {
+   stored_configuration = {
       "domains": 
       [
          telegraf.config( base, "telegrafA", user_config.get( "telegrafA")),
@@ -192,16 +109,16 @@ def on_test_start( environment, **kwargs):
       ]
    }
 
-   casual.on_test_start( configuration, environment)
-   starttime = helpers.write_start_information( configuration, environment)
+   casual.on_test_start( stored_configuration, environment)
+   starttime = helpers.write_start_information( stored_configuration, environment)
    time.sleep(5)
 
 @events.test_stop.add_listener
 def on_test_stop( environment, **kwargs):
    global starttime
-   global configuration
+   global stored_configuration
 
-   casual.on_test_stop( configuration, environment)
+   casual.on_test_stop( stored_configuration, environment)
 
-   helpers.write_stop_information( configuration, environment, starttime)
+   helpers.write_stop_information( stored_configuration, environment, starttime)
       

--- a/testCases/casual/casual/performance/test/configuration.py
+++ b/testCases/casual/casual/performance/test/configuration.py
@@ -1,0 +1,569 @@
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+import json
+import yaml
+
+
+####################################
+# Common configuration for gateway #
+####################################
+
+@dataclass
+class Discovery( object):
+    forward: bool = False
+
+@dataclass
+class Limit( object):
+    size: int = 0
+    messages: int = 0
+
+@dataclass
+class InboundConnection(object):
+    """
+    Connection information
+    """
+    address: str
+    discovery: Discovery = field(default_factory=Discovery)
+
+class InboundConnectionList(list):
+    """
+    List containing connection connected to this gateway group
+    """
+    def append( self, address: str):
+        if isinstance( address, InboundConnection):
+            super().append( address)
+        else:
+            super().append( InboundConnection( address))
+        return super().__getitem__(-1)
+
+    def find_first( self, alias):
+        for item in self:
+            if item.alias == alias:
+                return item
+        raise SystemError( f"{alias} not found")
+
+
+@dataclass
+class OutboundConnection(object):
+    """
+    Connection information
+    """
+    address: str
+    services: list = field(default_factory=list)
+    queues: list = field(default_factory=list)
+
+class OutboundConnectionList(list):
+    """
+    List containing connection connected to this gateway group
+    """
+    def append( self, address: str):
+        if isinstance( address, OutboundConnection):
+            super().append( address)
+        else:
+            super().append( OutboundConnection( address))
+        return super().__getitem__(-1)
+
+@dataclass 
+class InboundGroup( object):
+    alias: str
+    limit: Limit = field(default_factory=Limit)
+    connections: InboundConnectionList = field(default_factory=InboundConnectionList)
+
+class InboundGroupList( list):
+    def append( self, alias: str):
+        if isinstance( alias, InboundGroup):
+            super().append( alias)
+        else:
+            super().append( InboundGroup( alias))
+        return super().__getitem__(-1)
+
+    def find_first( self, alias):
+        for item in self:
+            if item.alias == alias:
+                return item
+        raise SystemError( f"{alias} not found")
+
+
+
+@dataclass 
+class OutboundGroup( object):
+    alias: str
+    connections: OutboundConnectionList = field(default_factory=OutboundConnectionList)
+
+class OutboundGroupList( list):
+    def append( self, alias: str):
+        if isinstance( alias, OutboundGroup):
+            super().append( alias)
+        else:
+            super().append( OutboundGroup( alias))
+        return super().__getitem__(-1)
+
+    def find_first( self, alias):
+        for item in self:
+            if item.alias == alias:
+                return item
+        raise SystemError( f"{alias} not found")
+
+
+@dataclass
+class Inbound(object):
+    default: dict = field(default_factory=dict)
+    groups: InboundGroupList = field(default_factory=InboundGroupList)
+
+@dataclass
+class Outbound(object):
+    groups: OutboundGroupList = field(default_factory=OutboundGroupList)
+
+@dataclass
+class Reverse(object):
+    groups: list = field(default_factory=list)
+
+@dataclass
+class GatewayMain(object):
+    """
+    Outer gateway section of configuration
+    """
+    inbound: Inbound = field(default_factory=Inbound)
+    outbound: Outbound = field(default_factory=Outbound)
+    reverse: Reverse = field(default_factory=Reverse)
+
+###################################################
+# Common configuration for server and executables #
+###################################################
+
+@dataclass
+class ServerExecutableData(object):
+    """
+    Baseclass for storing Server and Executables attributes
+    """
+    path: str
+    alias: str = ""
+    arguments: list = field(default_factory=list)
+    instances: int = 1
+    memberships: list = field(default_factory=list)
+    restart: bool = True
+    restrictions: list = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+#######################
+# Group configuration #
+#######################
+@dataclass
+class Group(object):
+    name: str
+    resources: list = field(default_factory=list)
+    dependencies: list = field(default_factory=list)
+
+class GroupList( list):
+    def append( self, name: str):
+        if isinstance( name, Group):
+            super().append( name)
+        else:
+            super().append( Group( name))
+        return super().__getitem__(-1)
+
+    def find_first( self, name):
+        for item in self:
+            if item.name == name:
+                return item
+        raise SystemError( f"{name} not found")
+
+#############################
+# Transaction configuration #
+#############################
+
+@dataclass
+class Resource(object):
+    """
+    Storage of Resource attributes
+    """
+    name: str
+    key: str
+    instances: int
+
+    def __init__(self, name: str = None, key: str = None, instances: int = 1):
+        self.name = name
+        self.key = key
+        self.instances = instances
+
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+class ResourceList(list):
+    def append( self, name: str = None, key: str = None, instances: int = 1):
+        if isinstance( name, Resource):
+            super().append( name)
+        else:
+            super().append( Resource( name, key, instances))
+        return super().__getitem__(-1)
+
+    def find_first( self, name):
+        for item in self:
+            if item.name == name:
+                return item
+        raise SystemError( f"{name} not found")
+
+class Transaction(object):
+    def __init__(self) -> None:
+        self.resources = ResourceList()
+
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+#########################
+# services configuration #
+#########################
+
+@dataclass
+class Timeout(object):
+    duration: str = "0s"
+    contract: str = "linger"
+
+@dataclass
+class Execution(object):
+    timeout: Timeout = field(default_factory=Timeout)
+@dataclass
+class Service(object):
+    name: str
+    execution: Execution = field(default_factory=Execution)
+    routes: list = field(default_factory=list)
+    visibility: str = "discoverable"
+
+
+@dataclass
+class ServiceList(list):
+    def append( self, name ):
+        if isinstance( name, Service):
+            super().append( name)
+        else:
+            super().append( Service( name))
+        return super().__getitem__(-1)
+
+    def find_first( self, name):
+        for item in self:
+            if item.name == name:
+                return item
+        raise SystemError( f"{name} not found")
+
+########################
+# server configuration #
+########################
+
+class Server(ServerExecutableData):
+    """
+    Server entry in model
+    """
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+class ServerList( list):
+    def append( self, path: str, alias = None, arguments: list = [], instances: int = 1, members: list = [] ):
+        if isinstance( path, Server):
+            super().append( path)
+        else:
+            super().append( Server( path, alias, arguments, instances, members))
+        return super().__getitem__(-1)
+
+    def find_first( self, alias):
+        for item in self:
+            if item.alias == alias:
+                return item
+        raise SystemError( f"{alias} not found")
+    
+############################
+# executable configuration #
+############################
+
+class Executable(ServerExecutableData):
+    """
+    Executable entry in model
+    """
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+class ExecutableList( list):
+    def append( self, path: str, alias = None, arguments: list = [], instances: int = 1, members: list = [] ):
+        if isinstance( path, Executable):
+            super().append( path)
+        else:
+            super().append( Executable( path, alias, arguments, instances, members))
+        return super().__getitem__(-1)
+
+    def find_first( self, alias):
+        for item in self:
+            if item.alias == alias:
+                return item
+        raise SystemError( f"{alias} not found")
+
+#######################
+# queue configuration #
+#######################
+
+@dataclass
+class QueueDefault(object):
+    pass
+
+@dataclass
+class QueueForwardDefault(object):
+    pass
+
+@dataclass
+class Reply(object):
+    queue: str
+    delay: str = "0s"
+
+@dataclass
+class ServiceTarget(object):
+    service: str
+
+@dataclass
+class QueueTarget(object):
+    queue: str
+
+@dataclass
+class ForwardQueueService(object):
+    source: str
+    target: ServiceTarget = field(default_factory=ServiceTarget)
+    instances: int = 1
+    reply: Reply = field(default_factory=Reply)
+
+    def __init__(self, source: str, target: ServiceTarget, instances: int = 1, queue = None, delay = None):
+        self.source = source
+        self.target = ServiceTarget(target)
+        self.instances = instances
+        self.reply = Reply( queue, delay) if queue else {}
+
+
+@dataclass
+class ForwardQueueQueue(object):
+    source: str
+    target: QueueTarget = field(default_factory=QueueTarget)
+    instances: int = 1
+
+    def __init__(self, source: str, target: QueueTarget, instances: int = 1):
+        self.source = source
+        self.target = QueueTarget( target) if target else {}
+        self.instances = instances
+
+class ForwardQueueServiceList(list):
+    def append( self, source, target, instances = 1, reply = None):
+        if isinstance( source, ForwardQueueService):
+            super().append( source, target, instances, reply )
+        else:
+            super().append( ForwardQueueService( source, target, instances, reply))
+        return super().__getitem__(-1)
+
+class ForwardQueueQueueList(list):
+    def append( self, source: str, target: QueueTarget, instances: int = 1):
+        if isinstance( source, ForwardQueueQueue):
+            super().append( source, target, instances)
+        else:
+            super().append( ForwardQueueQueue( source, target, instances)) 
+        return super().__getitem__(-1)
+
+@dataclass
+class ForwardQueueGroup(object):
+    alias: str
+    services: ForwardQueueServiceList = field(default_factory=ForwardQueueServiceList)
+    queues: ForwardQueueQueueList = field(default_factory=ForwardQueueQueueList)
+
+class ForwardQueueGroupList(list):
+    def append( self, alias):
+        if isinstance( alias, ForwardQueueGroup):
+            super().append( alias)
+        else:
+            super().append( ForwardQueueGroup( alias))
+        return super().__getitem__(-1)
+    
+    def find_first( self, alias):
+        for item in self:
+            if item.alias == alias:
+                return item
+        raise SystemError( f"{alias} not found")
+
+@dataclass
+class QueueForwardMain(object):
+    default: QueueForwardDefault = field(default_factory=QueueForwardDefault)
+    groups: ForwardQueueGroupList = field(default_factory=ForwardQueueGroupList)
+
+@dataclass
+class Retry(object):
+    count: int = 0
+    delay: str = "0s"
+
+@dataclass
+class Queue(object):
+    name: str
+    retry: Retry
+
+    def __init__( self, name, count, delay):
+        self.name = name
+        self.retry = Retry( count, delay)
+
+class QueueList( list):
+    def append( self, name, count = 0, delay = 0):
+        if isinstance( name, Queue):
+            super().append( name, count, delay)
+        else:
+            super().append( Queue( name, count, delay))
+        return super().__getitem__(-1)
+
+@dataclass 
+class QueueGroup( object):
+    """
+    Queuegroup
+    """
+    alias: str
+    queuebase: str
+    queues: QueueList[Queue] = field(default_factory=QueueList)
+
+@dataclass
+class QueueGroupList( list):
+    def append( self, alias: str = None, queuebase: str = None):
+        if not queuebase: queuebase = f"${{CASUAL_DOMAIN_HOME}}/queue/{alias}.qb"
+        if isinstance( alias, QueueGroup):
+            super().append( alias, queuebase)
+        else:
+            super().append( QueueGroup( alias, queuebase))
+        return super().__getitem__(-1)
+
+    def find_first( self, alias):
+        for item in self:
+            if item.alias == alias:
+                return item
+        raise SystemError( f"{alias} not found")
+
+@dataclass
+class QueueMain(object):
+    """
+    Outer queue section of configuration
+    """
+    default: QueueDefault = field(default_factory=QueueDefault)
+    groups: QueueGroupList = field(default_factory=QueueGroupList)
+    forward: QueueForwardMain = field(default_factory=QueueForwardMain)
+
+########################
+# domain configuration #
+########################
+
+class Domain(object):
+    """
+    Domain part of configuration. This groups all interessting configuration.
+    """
+    def __init__(self, name, default_transaction = True, eventlog = True, http_outbound = True, example_server = True):
+        self.name = name
+        self.groups = GroupList() 
+        self.servers = ServerList() 
+        self.executables = ExecutableList()
+        self.transaction = Transaction()
+        self.queue = QueueMain()
+        self.gateway = GatewayMain()
+        self.services = ServiceList()
+
+        if default_transaction:
+            self.transaction.resources.append( 
+                name = "example-resource-server",
+                key = "rm-mockup",
+                instances = 2
+            )
+
+        if eventlog:
+            self.executables.append( 
+                alias = "casual-event-service-log",
+                path = "${CASUAL_HOME}/bin/casual-event-service-log",
+                arguments = [ "--file", "logs/statistics.log" ],
+                instances = 1
+            )
+        if http_outbound:
+            self.executables.append( 
+                alias = "casual-http-inbound",
+                path = "${CASUAL_HOME}/nginx/sbin/nginx",
+                arguments = [ 
+                    "-c", 
+                    "${CASUAL_DOMAIN_HOME}/configuration/nginx.conf",
+                    "-p",
+                    "${CASUAL_DOMAIN_HOME}",
+                ],
+                instances = 1
+            )
+
+        if example_server:
+            self.servers.append(
+                alias = "casual-example-server",
+                path =  "${CASUAL_HOME}/example/bin/casual-example-server",
+                instances = 1
+            )
+
+
+    def __repr__(self):
+        return str(self.model())
+
+########################
+# system configuration #
+########################
+
+def default_system_configuration():
+    """
+    Definition of default system configuration for tests
+    """
+    return [
+        {
+            "key": "rm-mockup",
+            "server" : "rm-proxy-casual-mockup",
+            "xa_struct_name": "casual_mockup_xa_switch_static",
+            "libraries": [
+                "casual-mockup-rm"
+            ],
+            "paths" : {
+                "library" : [
+                    "${CASUAL_HOME}/lib"
+                ]
+            }
+        }
+    ]
+
+class System( object):
+    """
+    System section of configuration
+    """
+    def __init__(self):
+        self.resources = default_system_configuration()
+
+###############################
+# configuration configuration #
+###############################
+
+class Configuration(object):
+    """
+    Main configuration object
+    """
+    def __init__(self, name = None, default_transaction = True, eventlog = True, http_outbound = True, example_server = True):
+        self.domain = Domain( name, default_transaction, eventlog, http_outbound, example_server)
+        self.system = System()
+    
+    def as_json(self):
+        return json.dumps( self, indent=2, default=vars )
+    
+    def as_yaml(self):
+        model = json.loads( str(self.as_json()))
+        return yaml.dump(model)
+
+    def configuration_file_entry(self):
+        return {
+            "filename" : "configuration/domain.yaml",
+            "content" : self.as_yaml()
+        }
+
+    def from_yaml(self, document):
+        doc = yaml.safe_load(document)
+        jdoc = json.dumps( doc, indent=2, default=vars)
+        x = json.loads( str(jdoc), object_hook=lambda d: SimpleNamespace(**d))
+        self.__dict__.update( x.__dict__)
+
+if __name__ == '__main__':    
+
+    config_domain_X = Configuration( "example")
+    config_domain_X.domain.services.append("test-service")
+    print(config_domain_X.as_yaml())

--- a/testCases/casual/casual/unittest/configuration_test.py
+++ b/testCases/casual/casual/unittest/configuration_test.py
@@ -1,0 +1,116 @@
+import unittest
+from casual.performance.test import configuration
+
+class TestConfiguration(unittest.TestCase):
+
+    def test_main_empty_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        self.assertEqual(config_domain_X.domain.name, "domainX", 'There name is wrong.')
+        self.assertEqual(len( config_domain_X.domain.servers), 0, 'There should be no servers.')
+        self.assertEqual(len( config_domain_X.domain.executables), 0, 'There should be no executables.')
+
+    def test_main_exampleserver_configuration(self):
+        config_domain_X = configuration.Configuration( "domainY", False, False, False, example_server=True)
+        self.assertEqual(config_domain_X.domain.name, "domainY", 'There name is wrong.')
+        self.assertEqual(len( config_domain_X.domain.servers), 1, 'There should be no servers.')
+        self.assertEqual(len( config_domain_X.domain.executables), 0, 'There should be no executables.')
+        self.assertEqual( config_domain_X.domain.servers[0].alias, "casual-example-server", "There exampleserver is missing")
+
+    def test_main_testserver_configuration(self):
+        config_domain_X = configuration.Configuration( "domainY", False, False, False, False)
+        config_domain_X.domain.groups.append("test-group")
+        server = config_domain_X.domain.servers.append("/bin/path/test-server")
+        server.alias = "test-server"
+        server.arguments = [ "-c", "0" , "-f", "somefile" ]
+        server.memberships.append("test-group")
+        server.restrictions.append(".*")
+        self.assertEqual(config_domain_X.domain.name, "domainY", 'There name is wrong.')
+        self.assertEqual(len( config_domain_X.domain.servers), 1, 'There should be no servers.')
+        self.assertEqual(len( config_domain_X.domain.executables), 0, 'There should be no executables.')
+        self.assertEqual( config_domain_X.domain.servers[0].alias, "test-server", "There test-server is missing")
+        self.assertEqual( config_domain_X.domain.servers[0].memberships[0], "test-group", "There memberships is missing")
+        self.assertEqual( config_domain_X.domain.servers[0].path, "/bin/path/test-server", "There path is missing")
+        self.assertEqual( config_domain_X.domain.servers[0].restart, True, "There restart is wrong")
+        self.assertEqual( config_domain_X.domain.servers[0].restrictions[0], ".*", "There should be a restriction")
+
+
+    def test_main_queue_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        config_domain_X.domain.queue.groups.append("test-group").queues.append("test-queue", 3, "3ms")
+        self.assertEqual( len( config_domain_X.domain.queue.groups), 1, 'There should be a group.')
+        self.assertEqual( config_domain_X.domain.queue.groups[0].alias, "test-group", 'There should be a group.')
+        self.assertEqual( len(config_domain_X.domain.queue.groups[0].queues), 1, 'There should be a queue.') 
+        q =  config_domain_X.domain.queue.groups[0].queues[0]
+        self.assertEqual( q.name, "test-queue", 'There queue should have the name test-queue') 
+        self.assertEqual( q.retry.count, 3, 'There queue should have a retry count') 
+        self.assertEqual( q.retry.delay, "3ms", 'There queue should have a retry delay') 
+
+    def test_main_queueforwardservice_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        config_domain_X.domain.queue.forward.groups.append("test-group").services.append("test-queue", "test-service")
+        self.assertEqual( len( config_domain_X.domain.queue.forward.groups), 1, 'There should be a group.')
+        self.assertEqual( config_domain_X.domain.queue.forward.groups[0].alias, "test-group", 'There should be a group.')
+        self.assertEqual( len( config_domain_X.domain.queue.forward.groups[0].services), 1, 'There should be a forward service.') 
+        f =  config_domain_X.domain.queue.forward.groups[0].services[0]
+        self.assertEqual( f.source, "test-queue", 'There source should have the name test-queue') 
+        self.assertEqual( f.target.service, "test-service", 'There target should have been test-service') 
+
+    def test_main_queueforwardqueue_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        config_domain_X.domain.queue.forward.groups.append("test-group").queues.append("test-source-queue", "test-target-queue")
+        self.assertEqual( len( config_domain_X.domain.queue.forward.groups), 1, 'There should be a group.')
+        self.assertEqual( config_domain_X.domain.queue.forward.groups[0].alias, "test-group", 'There should be a group.')
+        self.assertEqual( len( config_domain_X.domain.queue.forward.groups[0].queues), 1, 'There should be a forward queue.') 
+        f =  config_domain_X.domain.queue.forward.groups[0].queues[0]
+        self.assertEqual( f.source, "test-source-queue", 'There source should have the name test-source-queue') 
+        self.assertEqual( f.target.queue, "test-target-queue", 'There target should have been test-target-queue') 
+
+    def test_main_gateway_inbound_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        config_domain_X.domain.gateway.inbound.groups.append("test-inbound-group").connections.append("localhost:1234")
+        self.assertEqual( len( config_domain_X.domain.gateway.inbound.groups), 1, 'There should be a group.')
+        self.assertEqual( config_domain_X.domain.gateway.inbound.groups[0].alias, "test-inbound-group", 'There should be a group alias.')
+        self.assertEqual( len( config_domain_X.domain.gateway.inbound.groups[0].connections), 1, 'There should be a connection.') 
+        self.assertEqual( config_domain_X.domain.gateway.inbound.groups[0].connections[0].address, "localhost:1234", 'There should be a connection.') 
+
+    def test_main_gateway_outbound_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        config_domain_X.domain.gateway.outbound.groups.append("test-outbound-group").connections.append("localhost:4321")
+        self.assertEqual( len( config_domain_X.domain.gateway.outbound.groups), 1, 'There should be a group.')
+        self.assertEqual( config_domain_X.domain.gateway.outbound.groups[0].alias, "test-outbound-group", 'There should be a group alias.')
+        self.assertEqual( len( config_domain_X.domain.gateway.outbound.groups[0].connections), 1, 'There should be a connection.') 
+        self.assertEqual( config_domain_X.domain.gateway.outbound.groups[0].connections[0].address, "localhost:4321", 'There should be a connection.') 
+        outbound = config_domain_X.domain.gateway.outbound.groups.find_first("test-outbound-group")
+        outbound.connections[0].services.append("service1")
+        outbound.connections[0].queues.append("queue1")
+        self.assertEqual( config_domain_X.domain.gateway.outbound.groups[0].connections[0].services[0], "service1", 'There should be a service.') 
+        self.assertEqual( config_domain_X.domain.gateway.outbound.groups[0].connections[0].queues[0], "queue1", 'There should be a queue.') 
+
+    def test_main_group_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        group = config_domain_X.domain.groups.append("test-group")
+        group.resources.append("test-resource")
+        group.dependencies.append("test-dependency")
+        self.assertEqual( len( config_domain_X.domain.groups), 1, 'There should be a group.')
+        self.assertEqual( config_domain_X.domain.groups[0].name, "test-group", 'There should be a group name.')
+        self.assertEqual( config_domain_X.domain.groups[0].resources[0], "test-resource", 'There should be a resource.')
+        self.assertEqual( config_domain_X.domain.groups[0].dependencies[0], "test-dependency", 'There should be a dependency.')
+
+    def test_main_service_configuration(self):
+        config_domain_X = configuration.Configuration( "domainX", False, False, False, False)
+        service = config_domain_X.domain.services.append("test-service")
+        service.routes.append("route1")
+        service.visibility = "undiscoverable"
+        service.execution.timeout.contract = "kill"
+        service.execution.timeout.duration = "97ms"
+        self.assertEqual( len( config_domain_X.domain.services), 1, 'There should be a service.')
+        self.assertEqual( config_domain_X.domain.services[0].name, "test-service", 'There should be a service name.')
+        self.assertEqual( config_domain_X.domain.services[0].visibility, "undiscoverable", 'There should be visibility undiscoverable.')
+        self.assertEqual( config_domain_X.domain.services[0].routes[0], "route1", 'There should be a route.')
+        self.assertEqual( config_domain_X.domain.services[0].execution.timeout.contract, "kill", 'There should be a contract kill .')
+        self.assertEqual( config_domain_X.domain.services[0].execution.timeout.duration, "97ms", 'There should be a duration of 97ms.')
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Has added a python model that follows casuals configuration model.

Has no support for defaults yet. Not sure if it is needed in a test framework, i.e. use explicit configuration and no defaults.

Resolves #4